### PR TITLE
fix: parameter for config.json

### DIFF
--- a/gravitee-inference-api/src/main/java/io/gravitee/inference/api/Constants.java
+++ b/gravitee-inference-api/src/main/java/io/gravitee/inference/api/Constants.java
@@ -36,6 +36,7 @@ public final class Constants {
   */
   public static final String MODEL_PATH = "modelPath";
   public static final String TOKENIZER_PATH = "tokenizerPath";
+  public static final String CONFIG_JSON_PATH = "configJsonPath";
 
   /*
     ONNX Constants


### PR DESCRIPTION
This is a typo fix correction for the inference service plugin
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-fix-configuration-param-omitted-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/gravitee-inference/1.1.1-fix-configuration-param-omitted-SNAPSHOT/gravitee-inference-1.1.1-fix-configuration-param-omitted-SNAPSHOT.zip)
  <!-- Version placeholder end -->
