### PR TITLE
fix(deps): multiple dependency updates

### DIFF
--- a/gravitee-inference-onnx/pom.xml
+++ b/gravitee-inference-onnx/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <onnxruntime.version>1.22.0</onnxruntime.version>
-    <jackson-databind.version>2.18.3</jackson-databind.version>
+    <jackson-databind.version>2.19.0</jackson-databind.version>
   </properties>
 
 

--- a/gravitee-inference-onnx/pom.xml
+++ b/gravitee-inference-onnx/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <onnxruntime.version>1.21.1</onnxruntime.version>
+    <onnxruntime.version>1.22.0</onnxruntime.version>
     <jackson-databind.version>2.18.3</jackson-databind.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.gravitee</groupId>
     <artifactId>gravitee-parent</artifactId>
-    <version>23.1.0</version>
+    <version>23.2.1</version>
   </parent>
 
   <groupId>io.gravitee.inference</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <gravitee-bom.version>8.2.22</gravitee-bom.version>
+    <gravitee-bom.version>8.3.0</gravitee-bom.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>
     <commons-math3.version>3.6.1</commons-math3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <commons-math3.version>3.6.1</commons-math3.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-    <ai.djl.version>0.32.0</ai.djl.version>
+    <ai.djl.version>0.33.0</ai.djl.version>
   </properties>
   <modules>
     <module>gravitee-inference-math</module>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.2-chore-renovate-updates-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/gravitee-inference/1.1.2-chore-renovate-updates-SNAPSHOT/gravitee-inference-1.1.2-chore-renovate-updates-SNAPSHOT.zip)
  <!-- Version placeholder end -->
