### PR TITLE
feat(perf): improve performance on classifiers

### DIFF
--- a/gravitee-inference-rest/src/main/java/io/gravitee/inference/rest/openai/OpenaiRestInference.java
+++ b/gravitee-inference-rest/src/main/java/io/gravitee/inference/rest/openai/OpenaiRestInference.java
@@ -23,8 +23,6 @@ import org.slf4j.LoggerFactory;
 
 public abstract class OpenaiRestInference<C extends RestConfig, O> extends RestInference<C, String, O> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(OpenaiRestInference.class);
-
   public OpenaiRestInference(C config, Vertx vertx) {
     super(config, vertx);
   }


### PR DESCRIPTION
This PR adds improvements in the way classification results are computed

- Sequence: if we have 2 labels, we just switch places, otherwise we sort instead of using a TreeSet
- Token: We only build the best token match for a given word
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.2-perf-performance-improvments-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/gravitee-inference/1.2.2-perf-performance-improvments-SNAPSHOT/gravitee-inference-1.2.2-perf-performance-improvments-SNAPSHOT.zip)
  <!-- Version placeholder end -->
