### PR TITLE
feat: add new inference formats

### DIFF
--- a/gravitee-inference-api/src/main/java/io/gravitee/inference/api/service/InferenceFormat.java
+++ b/gravitee-inference-api/src/main/java/io/gravitee/inference/api/service/InferenceFormat.java
@@ -21,4 +21,6 @@ package io.gravitee.inference.api.service;
  */
 public enum InferenceFormat {
   ONNX_BERT,
+  REST_OPENAI,
+  REST_HTTP,
 }

--- a/gravitee-inference-api/src/main/java/io/gravitee/inference/api/service/InferenceFormat.java
+++ b/gravitee-inference-api/src/main/java/io/gravitee/inference/api/service/InferenceFormat.java
@@ -21,6 +21,6 @@ package io.gravitee.inference.api.service;
  */
 public enum InferenceFormat {
   ONNX_BERT,
-  REST_OPENAI,
-  REST_HTTP,
+  OPENAI,
+  HTTP,
 }


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.0-feat-add-inference-formats-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/gravitee-inference/1.5.0-feat-add-inference-formats-SNAPSHOT/gravitee-inference-1.5.0-feat-add-inference-formats-SNAPSHOT.zip)
  <!-- Version placeholder end -->
