### PR TITLE
feat: wire bos eos tokens and chat template

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,3 +351,75 @@ When `rpcServers` is configured, model layers are distributed across remote GPU 
 | `WARN` | Log estimate at INFO, warn if model won't fit, continue loading. **Recommended for production.** |
 | `FAIL` | Log estimate at INFO, throw `InsufficientVramException` if model won't fit. Use in CI or strict environments. |
 | `DISABLED` | Skip the check entirely. Use when you know the model fits or the estimator is not needed. |
+
+---
+
+## vLLM Inference (HuggingFace models)
+
+`gravitee-inference-vllm` runs LLM inference using [vLLM](https://github.com/vllm-project/vllm) through an embedded CPython interpreter (via [vLLM4j](https://github.com/gravitee-io/vLLM4j)). Models are loaded directly from HuggingFace Hub — no GGUF conversion required.
+
+### Requirements
+
+- Linux with CUDA GPU (Metal not supported)
+- A Python virtual environment with vLLM installed:
+  ```sh
+  python -m venv .venv
+  source .venv/bin/activate
+  pip install vllm
+  ```
+- Pass the venv path via `-Dvllm4j.venv=/path/to/.venv` or `VLLM_VENV_PATH` env var
+
+### VllmConfig Reference
+
+| Parameter | Type | Description |
+|---|---|---|
+| `model` | `String` | HuggingFace model name (e.g. `Qwen/Qwen3-0.6B`). **Required.** |
+| `dtype` | `String` | Weight data type: `auto`, `float16`, `bfloat16`, `float32`. |
+| `quantization` | `String` | Quantization method: `gptq`, `awq`, `fp8`, or `null` (no quant). |
+| `maxModelLen` | `int` | Maximum sequence length (context window). |
+| `maxNumSeqs` | `int` | Maximum concurrent sequences. |
+| `gpuMemoryUtilization` | `float` | Fraction of GPU memory to use (0.0–1.0). |
+| `enforceEager` | `boolean` | Disable CUDA graphs for reduced memory. |
+| `trustRemoteCode` | `boolean` | Allow executing model-provided Python code. |
+| `enableChunkedPrefill` | `boolean` | Enable chunked prefill for long prompts. |
+| `enablePrefixCaching` | `boolean` | Cache shared prefixes across requests. |
+| `enableSleepMode` | `boolean` | Put the engine to sleep when idle. |
+| `memoryCheckPolicy` | `MemoryCheckPolicy` | Pre-flight memory check: `FAIL`, `WARN`, or `DISABLED`. |
+
+### Quick Start
+
+```java
+var config = VllmConfig.builder()
+    .model("Qwen/Qwen3-0.6B")
+    .dtype("auto")
+    .maxModelLen(4096)
+    .maxNumSeqs(1)
+    .gpuMemoryUtilization(0.35f)
+    .enforceEager(true)
+    .trustRemoteCode(true)
+    .build();
+
+var engine = new BatchEngine(config);
+engine.start(token -> {
+    System.out.print(token.token());
+    if (token.isFinal()) System.out.println();
+});
+
+var request = VllmRequest.builder()
+    .prompt("Hello, how are you?")
+    .maxTokens(256)
+    .temperature(0.7f)
+    .build();
+
+engine.addSequence(0, request);
+```
+
+### Chat Template
+
+The model's Jinja2 chat template is accessible via:
+
+```java
+String template = engine.chatTemplateString(); // from HuggingFace tokenizer_config.json
+String bos = engine.bosToken();
+String eos = engine.eosToken();
+```

--- a/gravitee-inference-api/src/main/java/io/gravitee/inference/api/template/ChatTemplateRenderer.java
+++ b/gravitee-inference-api/src/main/java/io/gravitee/inference/api/template/ChatTemplateRenderer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.inference.api.template;
+
+import io.gravitee.inference.api.textgen.ChatMessage;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ChatTemplateRenderer {
+  /**
+   * <p>{@code messages} and {@code tools} are only set when non-null — otherwise
+   * whatever the caller supplied via {@code extraVariables} is kept.
+   *
+   * @param templateString      the raw template
+   * @param messages            conversation messages, or {@code null} if supplied via extraVariables
+   * @param tools               tool definitions in OpenAI format, or {@code null}
+   * @param addGenerationPrompt whether to append the assistant generation prompt
+   * @param extraVariables      additional template variables, or {@code null}
+   * @return the rendered prompt string
+   */
+  String render(
+    String templateString,
+    List<ChatMessage> messages,
+    List<Map<String, Object>> tools,
+    boolean addGenerationPrompt,
+    Map<String, Object> extraVariables
+  );
+
+  /**
+   * Convenience overload without extra variables.
+   */
+  default String render(
+    String templateString,
+    List<ChatMessage> messages,
+    List<Map<String, Object>> tools,
+    boolean addGenerationPrompt
+  ) {
+    return render(templateString, messages, tools, addGenerationPrompt, null);
+  }
+}

--- a/gravitee-inference-llama-cpp/pom.xml
+++ b/gravitee-inference-llama-cpp/pom.xml
@@ -34,7 +34,7 @@
     <description>llama.cpp implementation of the Inference API</description>
 
     <properties>
-        <llamaj.cpp.version>1.0.3</llamaj.cpp.version>
+        <llamaj.cpp.version>1.1.0</llamaj.cpp.version>
     </properties>
 
     <dependencies>

--- a/gravitee-inference-llama-cpp/src/main/java/io/gravitee/inference/llama/cpp/BatchEngine.java
+++ b/gravitee-inference-llama-cpp/src/main/java/io/gravitee/inference/llama/cpp/BatchEngine.java
@@ -30,6 +30,8 @@ import java.util.function.Consumer;
  */
 public class BatchEngine extends AbstractBatchEngine<ModelConfig, Request, String, io.gravitee.llama.cpp.ConversationState> {
 
+  private final EngineAdapter engineAdapter;
+
   /**
    * Creates a new llama.cpp batch engine with default configuration.
    *
@@ -46,7 +48,25 @@ public class BatchEngine extends AbstractBatchEngine<ModelConfig, Request, Strin
    * @param modelConfig The model configuration
    */
   public BatchEngine(BatchEngineConfig engineConfig, ModelConfig modelConfig) {
-    super(engineConfig, new EngineAdapter(modelConfig));
+    this(engineConfig, new EngineAdapter(modelConfig));
+  }
+
+  private BatchEngine(BatchEngineConfig engineConfig, EngineAdapter adapter) {
+    super(engineConfig, adapter);
+    this.engineAdapter = adapter;
+  }
+
+  /** Returns the raw chat template string from the GGUF model. */
+  public String chatTemplateString() {
+    return engineAdapter.model().chatTemplateString();
+  }
+
+  public String bosToken() {
+    return engineAdapter.model().bosToken();
+  }
+
+  public String eosToken() {
+    return engineAdapter.model().eosToken();
   }
 
   /**

--- a/gravitee-inference-llama-cpp/src/main/java/io/gravitee/inference/llama/cpp/EngineAdapter.java
+++ b/gravitee-inference-llama-cpp/src/main/java/io/gravitee/inference/llama/cpp/EngineAdapter.java
@@ -51,6 +51,11 @@ public class EngineAdapter
     this.iterator = model.newBatchIterator();
   }
 
+  /** Returns the underlying model instance. */
+  public Model model() {
+    return model;
+  }
+
   private static void runMemoryCheck(ModelConfig config) {
     MemoryCheckPolicy policy = config.memoryCheckPolicy();
     if (policy == null || policy == MemoryCheckPolicy.DISABLED) {

--- a/gravitee-inference-llama-cpp/src/main/java/io/gravitee/inference/llama/cpp/Model.java
+++ b/gravitee-inference-llama-cpp/src/main/java/io/gravitee/inference/llama/cpp/Model.java
@@ -50,6 +50,10 @@ public final class Model implements AutoCloseable {
   private final LlamaLogger logger;
   private final MtmdContext mtmdContext;
 
+  // Memoized chat template string — read once from GGUF metadata.
+  private volatile String chatTemplateString;
+  private volatile boolean chatTemplateResolved;
+
   public Model(ModelConfig config) {
     this.arena = Arena.ofAuto();
 
@@ -158,6 +162,32 @@ public final class Model implements AutoCloseable {
     return mtmdContext;
   }
 
+  /** Returns the chat template from GGUF metadata, or {@code null}. */
+  public String chatTemplateString() {
+    if (!chatTemplateResolved) {
+      synchronized (this) {
+        if (!chatTemplateResolved) {
+          try {
+            chatTemplateString = new LlamaTemplate(model).templateString();
+          } catch (Exception e) {
+            LOGGER.debug("Could not read chat template from model: {}", e.getMessage());
+            chatTemplateString = null;
+          }
+          chatTemplateResolved = true;
+        }
+      }
+    }
+    return chatTemplateString;
+  }
+
+  public String bosToken() {
+    return vocab.bosTokenText();
+  }
+
+  public String eosToken() {
+    return vocab.eosTokenText();
+  }
+
   public ConversationState newConversation(int seqId, Request request) {
     Objects.requireNonNull(request, "request is required");
     String prompt = promptFor(request);
@@ -220,10 +250,15 @@ public final class Model implements AutoCloseable {
   }
 
   public String promptFor(Request request) {
+    // Pre-rendered prompt takes precedence over native template application.
+    if (request.prompt() != null && !request.prompt().isBlank()) {
+      return request.prompt();
+    }
+    // Fallback: apply the native chat template (direct model path).
     if (request.hasMessages()) {
       return buildChatPrompt(request.messages());
     }
-    return Objects.requireNonNullElse(request.prompt(), "");
+    return "";
   }
 
   public PromptStats promptStats(Request request) {

--- a/gravitee-inference-vllm/pom.xml
+++ b/gravitee-inference-vllm/pom.xml
@@ -33,7 +33,7 @@
     <description>vLLM implementation of the Inference API</description>
 
     <properties>
-        <vllm4j.version>0.1.0</vllm4j.version>
+        <vllm4j.version>0.2.0</vllm4j.version>
     </properties>
 
     <dependencies>

--- a/gravitee-inference-vllm/src/main/java/io/gravitee/inference/vllm/BatchEngine.java
+++ b/gravitee-inference-vllm/src/main/java/io/gravitee/inference/vllm/BatchEngine.java
@@ -33,6 +33,8 @@ import java.util.function.Consumer;
  */
 public class BatchEngine extends AbstractBatchEngine<VllmConfig, VllmRequest, String, EngineAdapter.VllmSequenceState> {
 
+  private final EngineAdapter engineAdapter;
+
   /**
    * Creates a new vLLM batch engine with default configuration.
    *
@@ -49,7 +51,25 @@ public class BatchEngine extends AbstractBatchEngine<VllmConfig, VllmRequest, St
    * @param vllmConfig The vLLM configuration
    */
   public BatchEngine(BatchEngineConfig engineConfig, VllmConfig vllmConfig) {
-    super(engineConfig, new EngineAdapter(vllmConfig));
+    this(engineConfig, new EngineAdapter(vllmConfig));
+  }
+
+  private BatchEngine(BatchEngineConfig engineConfig, EngineAdapter adapter) {
+    super(engineConfig, adapter);
+    this.engineAdapter = adapter;
+  }
+
+  /** Returns the raw chat template string from the HuggingFace tokenizer. */
+  public String chatTemplateString() {
+    return engineAdapter.chatTemplateString();
+  }
+
+  public String bosToken() {
+    return engineAdapter.bosToken();
+  }
+
+  public String eosToken() {
+    return engineAdapter.eosToken();
   }
 
   /**

--- a/gravitee-inference-vllm/src/main/java/io/gravitee/inference/vllm/EngineAdapter.java
+++ b/gravitee-inference-vllm/src/main/java/io/gravitee/inference/vllm/EngineAdapter.java
@@ -35,10 +35,6 @@ import io.gravitee.vllm.iterator.VllmIterator;
 import io.gravitee.vllm.iterator.VllmOutput;
 import io.gravitee.vllm.runtime.PythonRuntime;
 import io.gravitee.vllm.state.ConversationState;
-import io.gravitee.vllm.template.ChatMessage;
-import io.gravitee.vllm.template.ChatTemplate;
-import io.gravitee.vllm.template.Tool;
-import io.gravitee.vllm.template.ToolFunction;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +63,6 @@ public class EngineAdapter
 
   private final VllmEngine engine;
   private final VllmIterator iterator;
-  private final ChatTemplate chatTemplate;
 
   /** Tracks per-sequence state keyed by internal ID. */
   private final Map<Integer, VllmSequenceState> states = new ConcurrentHashMap<>();
@@ -120,7 +115,19 @@ public class EngineAdapter
     runMemoryCheck(config);
     this.engine = builder.build();
     this.iterator = new VllmIterator(engine);
-    this.chatTemplate = new ChatTemplate(engine);
+  }
+
+  /** Returns the raw chat template string from the HuggingFace tokenizer. */
+  public String chatTemplateString() {
+    return engine.getChatTemplate();
+  }
+
+  public String bosToken() {
+    return engine.getBosToken();
+  }
+
+  public String eosToken() {
+    return engine.getEosToken();
   }
 
   private static void runMemoryCheck(VllmConfig config) {
@@ -184,43 +191,19 @@ public class EngineAdapter
 
   @Override
   public VllmSequenceState createSequenceState(int internalId, VllmRequest request) throws Exception {
-    // Render prompt using chat template if messages are present
+    // Prompt must be pre-rendered by the caller — this adapter does not template.
     String prompt = request.prompt();
     MultiModalData multiModalData = null;
 
     if (request.hasMessages() && request.messages() != null) {
-      // Collect multimodal data (images, audio) from all messages
       multiModalData = extractMultiModalData(request.messages());
-
-      List<ChatMessage> vllmMessages = request
-        .messages()
-        .stream()
-        .map(msg -> {
-          String content = msg.content();
-          // For multimodal messages, build content parts list for the Jinja2 template
-          if (msg.hasMedia()) {
-            List<Map<String, Object>> contentParts = buildContentParts(msg);
-            return ChatMessage.userWithParts(content, contentParts);
-          }
-          return switch (msg.role()) {
-            case SYSTEM -> ChatMessage.system(content);
-            case ASSISTANT -> ChatMessage.assistant(content);
-            default -> ChatMessage.user(content);
-          };
-        })
-        .toList();
-
-      // Convert tools from OpenAI format (Map) to vLLM4J Tool DSL
-      List<Tool> vllmTools = convertTools(request.tools());
-      if (vllmTools != null && !vllmTools.isEmpty()) {
-        prompt = chatTemplate.render(vllmMessages, vllmTools, true);
-      } else {
-        prompt = chatTemplate.render(vllmMessages, true);
-      }
     }
 
     if (prompt == null || prompt.isBlank()) {
-      LOGGER.error("Cannot create sequence state: prompt is empty for internalId {}", internalId);
+      LOGGER.error(
+        "Cannot create sequence state: prompt is empty for internalId {} — vLLM requires a pre-rendered prompt",
+        internalId
+      );
       return null;
     }
 
@@ -422,43 +405,6 @@ public class EngineAdapter
   }
 
   /**
-   * Builds OpenAI-format content parts list for a multimodal message.
-   *
-   * <p>Converts the Gravitee API {@link io.gravitee.inference.api.textgen.ChatMessage}
-   * into the format that VLM Jinja2 templates expect:
-   * <pre>{@code
-   * [{"type": "text", "text": "Describe this image"},
-   *  {"type": "image"}]
-   * }</pre>
-   *
-   * <p>The image/audio binary data is passed separately via {@link MultiModalData},
-   * not embedded in the content parts. The template just needs to know that an
-   * image is present (via {@code {"type": "image"}}) to insert placeholder tokens.
-   *
-   * @param msg a message with media content
-   * @return list of content part maps in OpenAI format
-   */
-  private static List<Map<String, Object>> buildContentParts(io.gravitee.inference.api.textgen.ChatMessage msg) {
-    List<Map<String, Object>> parts = new java.util.ArrayList<>();
-
-    // Add text part if present
-    if (msg.hasText()) {
-      parts.add(Map.of("type", "text", "text", msg.content()));
-    }
-
-    // Add media placeholders — the actual bytes are in MultiModalData
-    for (Content content : msg.media()) {
-      if (content instanceof ImageContent) {
-        parts.add(Map.of("type", "image"));
-      } else if (content instanceof AudioContent) {
-        parts.add(Map.of("type", "audio"));
-      }
-    }
-
-    return parts;
-  }
-
-  /**
    * Extracts multimodal data (images, audio) from chat messages.
    *
    * <p>Iterates over all messages, collecting any {@link ImageContent} or
@@ -500,38 +446,6 @@ public class EngineAdapter
     }
 
     return mmData;
-  }
-
-  /**
-   * Converts OpenAI-format tools (List of Maps) to vLLM4J {@link Tool} DSL objects.
-   *
-   * <p>Each tool map follows the OpenAI format:
-   * <pre>{@code
-   * {"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}
-   * }</pre>
-   *
-   * @param tools the raw OpenAI tools from the request payload, or null
-   * @return list of vLLM4J Tool objects, or null if input is null/empty
-   */
-  @SuppressWarnings("unchecked")
-  private static List<Tool> convertTools(List<Map<String, Object>> tools) {
-    if (tools == null || tools.isEmpty()) {
-      return null;
-    }
-    List<Tool> result = new java.util.ArrayList<>();
-    for (Map<String, Object> toolMap : tools) {
-      Object functionObj = toolMap.get("function");
-      if (!(functionObj instanceof Map<?, ?> functionMap)) {
-        continue;
-      }
-      String name = functionMap.get("name") instanceof String s ? s : null;
-      String description = functionMap.get("description") instanceof String s ? s : null;
-      Map<String, Object> parameters = functionMap.get("parameters") instanceof Map<?, ?> p ? (Map<String, Object>) p : null;
-      if (name != null) {
-        result.add(Tool.function(name, description != null ? description : "", parameters));
-      }
-    }
-    return result.isEmpty() ? null : result;
   }
 
   /**


### PR DESCRIPTION
Exposes BOS/EOS tokens and the model's chat template string from both llama.cpp and vLLM engines. Removes vLLM's CPython template renderer, prompt rendering is now entirely the caller's responsibility. Adds the ChatTemplateRenderer interface as a pure contract.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-feat-template-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/gravitee-inference/2.0.0-feat-template-SNAPSHOT/gravitee-inference-2.0.0-feat-template-SNAPSHOT.zip)
  <!-- Version placeholder end -->
