### PR TITLE
Fix ONNX BERT partitioning & batch sizing

### DIFF
--- a/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/OnnxBertInference.java
+++ b/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/OnnxBertInference.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
@@ -109,6 +110,38 @@ public abstract class OnnxBertInference<OUTPUT>
         inputs.put(TOKEN_TYPE_IDS, tokenTypeIdsTensor);
       }
       return new EncodingResults(List.of(encoding), session.run(inputs));
+    } catch (OrtException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  protected Result encode(long[] inputIds) {
+    long[] attentionMask = new long[inputIds.length];
+    Arrays.fill(attentionMask, 1L);
+
+    long[] shape = { 1, inputIds.length };
+
+    try (
+      var inputIdsTensor = createTensor(environment, wrap(inputIds), shape);
+      var attentionMaskTensor = createTensor(
+        environment,
+        wrap(attentionMask),
+        shape
+      );
+    ) {
+      var inputs = new HashMap<String, OnnxTensor>();
+      inputs.put(INPUT_IDS, inputIdsTensor);
+      inputs.put(ATTENTION_MASK, attentionMaskTensor);
+
+      if (hasTokenTypeIds) {
+        var tokenTypeIdsTensor = createTensor(
+          environment,
+          wrap(new long[inputIds.length]),
+          shape
+        );
+        inputs.put(TOKEN_TYPE_IDS, tokenTypeIdsTensor);
+      }
+      return session.run(inputs);
     } catch (OrtException e) {
       throw new IllegalArgumentException(e);
     }

--- a/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/OnnxBertInference.java
+++ b/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/OnnxBertInference.java
@@ -153,7 +153,7 @@ public abstract class OnnxBertInference<OUTPUT>
 
     for (String sentence : sentences) {
       var encoding = tokenizer.encode(sentence, true, false);
-      maxTokens += encoding.getIds().length;
+      maxTokens = Math.max(maxTokens, encoding.getIds().length);
       encodings.add(encoding);
     }
 

--- a/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/OnnxBertInference.java
+++ b/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/OnnxBertInference.java
@@ -96,17 +96,15 @@ public abstract class OnnxBertInference<OUTPUT>
         wrap(attentionMask),
         shape
       );
+      var tokenTypeIdsTensor = hasTokenTypeIds
+        ? createTensor(environment, wrap(encoding.getTypeIds()), shape)
+        : null;
     ) {
       var inputs = new HashMap<String, OnnxTensor>();
       inputs.put(INPUT_IDS, inputIdsTensor);
       inputs.put(ATTENTION_MASK, attentionMaskTensor);
 
-      if (hasTokenTypeIds) {
-        var tokenTypeIdsTensor = createTensor(
-          environment,
-          wrap(encoding.getTypeIds()),
-          shape
-        );
+      if (tokenTypeIdsTensor != null) {
         inputs.put(TOKEN_TYPE_IDS, tokenTypeIdsTensor);
       }
       return new EncodingResults(List.of(encoding), session.run(inputs));
@@ -128,17 +126,15 @@ public abstract class OnnxBertInference<OUTPUT>
         wrap(attentionMask),
         shape
       );
+      var tokenTypeIdsTensor = hasTokenTypeIds
+        ? createTensor(environment, wrap(new long[inputIds.length]), shape)
+        : null;
     ) {
       var inputs = new HashMap<String, OnnxTensor>();
       inputs.put(INPUT_IDS, inputIdsTensor);
       inputs.put(ATTENTION_MASK, attentionMaskTensor);
 
-      if (hasTokenTypeIds) {
-        var tokenTypeIdsTensor = createTensor(
-          environment,
-          wrap(new long[inputIds.length]),
-          shape
-        );
+      if (tokenTypeIdsTensor != null) {
         inputs.put(TOKEN_TYPE_IDS, tokenTypeIdsTensor);
       }
       return session.run(inputs);

--- a/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/embedding/OnnxBertEmbeddingModel.java
+++ b/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/embedding/OnnxBertEmbeddingModel.java
@@ -56,6 +56,10 @@ public class OnnxBertEmbeddingModel
     final int partitionSize = config.get(MAX_SEQUENCE_LENGTH);
 
     long[] ids = tokenizer.encode(input, true, false).getIds();
+    if (ids.length <= 2) {
+      // no content tokens between [CLS] and [SEP] — nothing to embed
+      return new EmbeddingsWithWeights(new float[0][], new float[0]);
+    }
     final int lastIndex = ids.length - 1; // index of the [SEP] token
     final long clsId = ids[0];
     final long sepId = ids[lastIndex];

--- a/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/embedding/OnnxBertEmbeddingModel.java
+++ b/gravitee-inference-onnx/src/main/java/io/gravitee/inference/onnx/bert/embedding/OnnxBertEmbeddingModel.java
@@ -17,7 +17,9 @@ package io.gravitee.inference.onnx.bert.embedding;
 
 import static io.gravitee.inference.api.Constants.MAX_SEQUENCE_LENGTH;
 import static io.gravitee.inference.api.Constants.POOLING_MODE;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.System.arraycopy;
 import static java.util.stream.IntStream.iterate;
 
 import ai.onnxruntime.OrtException;
@@ -42,7 +44,7 @@ public class OnnxBertEmbeddingModel
   @Override
   public EmbeddingTokenCount infer(String input) {
     var tokens = tokenizer.tokenize(input);
-    var embeddings = getEmbeddings(input, tokens.size());
+    var embeddings = getEmbeddings(input);
 
     return new EmbeddingTokenCount(
       embeddings.toNormalizedWeighted(config.gioMath()),
@@ -50,11 +52,19 @@ public class OnnxBertEmbeddingModel
     );
   }
 
-  private EmbeddingsWithWeights getEmbeddings(String input, int size) {
+  private EmbeddingsWithWeights getEmbeddings(String input) {
     final int partitionSize = config.get(MAX_SEQUENCE_LENGTH);
-    final int lastIndex = size - 1;
 
-    final int nbPartitions = (size / partitionSize) + 1;
+    long[] ids = tokenizer.encode(input, true, false).getIds();
+    final int lastIndex = ids.length - 1; // index of the [SEP] token
+    final long clsId = ids[0];
+    final long sepId = ids[lastIndex];
+
+    final int contentSize = max(lastIndex - 1, 0); // tokens without [CLS]/[SEP]
+    final int nbPartitions = max(
+      (contentSize + partitionSize - 1) / partitionSize,
+      1
+    );
     var weights = new float[nbPartitions];
     var embeddings = new float[nbPartitions][];
 
@@ -63,14 +73,32 @@ public class OnnxBertEmbeddingModel
       from -> {
         int to = min(lastIndex, from + partitionSize);
         int index = (from - 1) / partitionSize;
-        try (var partition = encode(input).result()) {
+        try (var partition = encode(chunk(ids, clsId, sepId, from, to))) {
           embeddings[index] = toEmbedding(partition);
-          weights[index] = partition.size();
+          weights[index] = (float) (to - from);
         }
       }
     );
 
     return new EmbeddingsWithWeights(embeddings, weights);
+  }
+
+  /**
+   * Builds a standalone partition by re-wrapping the token id slice
+   * {@code [from, to)} with the [CLS] and [SEP] special tokens.
+   */
+  private static long[] chunk(
+    long[] ids,
+    long clsId,
+    long sepId,
+    int from,
+    int to
+  ) {
+    long[] partition = new long[(to - from) + 2];
+    partition[0] = clsId;
+    arraycopy(ids, from, partition, 1, to - from);
+    partition[partition.length - 1] = sepId;
+    return partition;
   }
 
   private float[] toEmbedding(Result result) {


### PR DESCRIPTION
This PR fixes:
  - getEmbeddings: actually chunk long inputs — encode each token slice (was re-encoding the whole input every
  iteration), weight by token count (was Result.size()), and fix partition-array over-allocation.
  - encodeAll: size the batch tensor to the max sequence length instead of the sum (was quadratic; results were
  already correct).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-fix-various-fixes-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/gravitee-inference/2.0.1-fix-various-fixes-SNAPSHOT/gravitee-inference-2.0.1-fix-various-fixes-SNAPSHOT.zip)
  <!-- Version placeholder end -->
